### PR TITLE
Support stylelint@^10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-css-modules",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "Extended ruleset for stylelint on CSS modules",
   "keywords": [
     "stylelint",
@@ -23,6 +23,6 @@
     "stylelint": "^9.10.1"
   },
   "peerDependencies": {
-    "stylelint": "^9.0.0"
+    "stylelint": "^9.0.0 || ^10.0.0"
   }
 }


### PR DESCRIPTION
It works with 10.1.0 at the very least. Though, I wonder how I _could_ test that the plugin works on varying Stylelint versions...

Closes https://github.com/juanca/stylelint-css-modules/issues/5